### PR TITLE
Implement Weekday puzzle variant

### DIFF
--- a/examples/today-is.rs
+++ b/examples/today-is.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use chrono::{Datelike, Days, Local, NaiveDate};
 use clap::Parser;
 use std::str::FromStr;
-use today_puzzle::variants::{CreaMakerspace, DragonFjord, JarringWords, Tetromino, Variant};
+use today_puzzle::variants::{CreaMakerspace, DragonFjord, JarringWords, Tetromino, Variant, Weekday};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -44,6 +44,7 @@ enum VariantOpt {
     CreaMakerspace,
     JarringWords,
     Tetromino,
+    Weekday,
 }
 
 // Date structure that we can parse as either M-D or Y-M-D
@@ -118,6 +119,7 @@ fn solve_and_print(variant: VariantOpt, LazyDate(date): LazyDate, print: Print) 
             JarringWords::board(date).solve(&JarringWords::pieces(), only_first)
         }
         VariantOpt::Tetromino => Tetromino::board(date).solve(&Tetromino::pieces(), only_first),
+        VariantOpt::Weekday => Weekday::board(date).solve(&Weekday::pieces(), only_first),
     };
 
     for solution in &solutions {

--- a/examples/today-is.rs
+++ b/examples/today-is.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use chrono::{Datelike, Days, Local, NaiveDate};
+use chrono::{Datelike, Days, Local, NaiveDate, Utc};
 use clap::Parser;
 use std::str::FromStr;
 use today_puzzle::variants::{CreaMakerspace, DragonFjord, JarringWords, Tetromino, Variant, Weekday};
@@ -70,9 +70,10 @@ impl FromStr for LazyDate {
         let d = match NaiveDate::parse_from_str(s, "%Y-%m-%d") {
             Ok(d) => d,
             Err(err) => {
-                // Prepend 2020 since it's a leap year
-                let s2020 = format!("2020-{}", s);
-                NaiveDate::parse_from_str(&s2020, "%Y-%m-%d").map_err(|_| err)?
+                // Prepend the current year
+                let year = Utc::now().year();
+                let maybe_ymd = format!("{}-{}", year, s);
+                NaiveDate::parse_from_str(&maybe_ymd, "%Y-%m-%d").map_err(|_| err)?
             }
         };
 

--- a/public/index.html
+++ b/public/index.html
@@ -83,6 +83,7 @@
     <option value="1" selected>JarringWords</option>
     <option value="2">CreaMakerspace</option>
     <option value="3">Tetromino</option>
+    <option value="4">Weekday</option>
   </select>
   <div id="puzzle-control">
     <input id="prev-day" type="button" value="<">
@@ -97,14 +98,23 @@
   <script type="module">
     import init, { solve_once } from './pkg/today_puzzle.js'
 
-    function monthsForLocale(localeName = 'en-US', monthFormat = 'short') {
-      const format = new Intl
-        .DateTimeFormat(localeName, { month: monthFormat }).format
+    function locale(property = 'month', localeName = 'en-US', format = 'short') {
+      let opt = {}
+      opt[property] = format
+      return new Intl.DateTimeFormat(localeName, opt).format
+    }
+    function monthsForLocale() {
+      const format = locale('month')
       return [...Array(12).keys()]
         .map((m) => format(new Date(Date.UTC(2021, (m + 1) % 12))))
     }
+    function weekdaysForLocale() {
+      const format = locale('weekday')
+      return [...Array(7).keys()]
+        .map((d) => format(new Date(Date.UTC(2021, 0, d + 4))))
+    }
     const MONTHS = monthsForLocale()
-
+    const WEEKDAYS = weekdaysForLocale()
 
     function getStandardSquareText(n) {
       if (n % 8 === 7 || n === 6 || n === 14 || n > 50) { return '' }
@@ -127,6 +137,14 @@
       if (n < 40) { return n - 17 }
       if (n < 48) { return n - 18 }
       if (n <= 54) { return n - 23 }
+      console.log("Unknown square: " + n)
+    }
+
+    function getWeekdaySquareText(n) {
+      if (n <= 50) { return getStandardSquareText(n) }
+      if (n <= 54) { return WEEKDAYS[n-51] }
+      if (n <= 59 || n > 62) { return '' }
+      if (n <= 62) { return WEEKDAYS[n-56]}
       console.log("Unknown square: " + n)
     }
 
@@ -176,7 +194,7 @@
 
     function solve(variant, date) {
       console.log('Solving for ' + date.toLocaleDateString())
-      return makeBoard(solve_once(date.getMonth() + 1, date.getDate(), variant))
+      return makeBoard(solve_once(BigInt(date.getTime()), variant))
     }
 
     async function run() {
@@ -197,6 +215,8 @@
       let variant = vp.value
       if(variant === "3") {
         getSquareText = getTetrominoSquareText
+      } else if (variant === "4") {
+        getSquareText = getWeekdaySquareText
       } else {
         getSquareText = getStandardSquareText        
       }      

--- a/src/variants.rs
+++ b/src/variants.rs
@@ -214,27 +214,13 @@ pub(crate) fn tetromino_bitboard_from_date(d: NaiveDate) -> BitBoard {
 
 /// Generates a weekday bitboard with only the month, day, and weekday cleared
 pub(crate) fn weekday_bitboard_from_date(d: NaiveDate) -> BitBoard {
-    let month_part = match d.month() {
-        m @ 1..=6 => 1 << (16 - m),
-        m @ 7..=12 => 1 << (14 - m),
-        _ => unreachable!("Invalid month"),
-    };
-    let day_part = match d.day() {
-        d @ 1..=7 => 1 << (48 - d),
-        d @ 8..=14 => 1 << (47 - d),
-        d @ 15..=21 => 1 << (46 - d),
-        d @ 22..=28 => 1 << (45 - d),
-        d @ 29..=31 => 1 << (44 - d),
-        _ => unreachable!("Invalid day"),
-    };
-
     let dow_part = match d.weekday().num_days_from_sunday() {
         d @ 0..=3 => 1 << (12 - d),
         d @ 4..=6 => 1 << (7 - d),
         _ => unreachable!("Invalid day of week"),
     };
 
-    BitBoard(!((month_part << 48) | day_part | dow_part))
+    standard_bitboard_from_date(d) & BitBoard(!dow_part)
 }
 
 

--- a/src/variants.rs
+++ b/src/variants.rs
@@ -38,6 +38,23 @@ pub const BITBOARD_STANDARD: BitBoard = BitBoard(0x0303_0101_0101_1FFF);
 /// ```
 pub const BITBOARD_TETROMINO: BitBoard = BitBoard(0x0303_0101_0101_F1FF);
 
+/// Board [with weekdays](https://github.com/keiichiw/a-puzzle-a-day-solver/issues/3):
+///
+/// Board is shaped as follows:
+///
+/// ```ignore
+/// Ja Fe Ma Ap Ma Ju XX XX  - 0x03
+/// Ju Au Se Oc No De XX XX  - 0x03
+/// 01 02 03 04 05 06 07 XX  - 0x01
+/// 08 09 10 11 12 13 14 XX  - 0x01
+/// 15 16 17 18 19 20 21 XX  - 0x01
+/// 22 23 24 25 26 27 28 XX  - 0x01
+/// 29 30 31 Su Mo Tu We XX  - 0x01
+/// XX XX XX XX Th Fr Sa XX  - 0xF1
+/// ```
+pub const BITBOARD_WEEKDAY: BitBoard = BitBoard(0x0303_0101_0101_01F1);
+
+
 pub trait Variant<const N: usize>: Sized {
     fn board(date: NaiveDate) -> Board<N>;
     fn pieces() -> [Piece; N];
@@ -135,6 +152,28 @@ impl Variant<9> for Tetromino {
     }
 }
 
+pub struct Weekday;
+impl Variant<10> for Weekday {
+    fn board(date: NaiveDate) -> Board<10> {
+        Board::new(BITBOARD_WEEKDAY, weekday_bitboard_from_date(date))
+    }
+
+    fn pieces() -> [Piece; 10] {
+        [
+            PIECE_LINE.as_ref(),
+            PIECE_U.as_ref(),
+            PIECE_L.as_ref(),
+            PIECE_TALL_L.as_ref(),
+            PIECE_Z.as_ref(),
+            PIECE_LONG_Z.as_ref(),
+            PIECE_TALL_S.as_ref(),
+            PIECE_TALL_T.as_ref(),
+            PIECE_CORNER.as_ref(),
+            PIECE_SIX.as_ref(),
+        ]
+    }
+}
+
 /// Generates a standard bitboard with only the month and day cleared
 pub(crate) fn standard_bitboard_from_date(d: NaiveDate) -> BitBoard {
     let month_part = match d.month() {
@@ -173,12 +212,42 @@ pub(crate) fn tetromino_bitboard_from_date(d: NaiveDate) -> BitBoard {
     BitBoard(!((month_part << 48) | day_part))
 }
 
+/// Generates a weekday bitboard with only the month, day, and weekday cleared
+pub(crate) fn weekday_bitboard_from_date(d: NaiveDate) -> BitBoard {
+    let month_part = match d.month() {
+        m @ 1..=6 => 1 << (16 - m),
+        m @ 7..=12 => 1 << (14 - m),
+        _ => unreachable!("Invalid month"),
+    };
+    let day_part = match d.day() {
+        d @ 1..=7 => 1 << (48 - d),
+        d @ 8..=14 => 1 << (47 - d),
+        d @ 15..=21 => 1 << (46 - d),
+        d @ 22..=28 => 1 << (45 - d),
+        d @ 29..=31 => 1 << (44 - d),
+        _ => unreachable!("Invalid day"),
+    };
+
+    let dow_part = match d.weekday().num_days_from_sunday() {
+        d @ 0..=3 => 1 << (12 - d),
+        d @ 4..=6 => 1 << (7 - d),
+        _ => unreachable!("Invalid day of week"),
+    };
+
+    BitBoard(!((month_part << 48) | day_part | dow_part))
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn test_date() -> NaiveDate {
-        chrono::NaiveDate::from_ymd_opt(20, 12, 1).unwrap()
+        chrono::NaiveDate::from_ymd_opt(2020, 12, 1).unwrap()
+    }
+
+    fn ymd(year: i32, month: u32, day: u32) -> NaiveDate {
+        chrono::NaiveDate::from_ymd_opt(year, month, day).unwrap()
     }
 
     fn assert_solution(solution: Solution, range: impl Iterator<Item = char>) {
@@ -215,4 +284,17 @@ mod tests {
         let solution = Tetromino::solve_once(test_date()).expect("did not find solution");
         assert_solution(solution, 'A'..='I')
     }
+
+    #[test]
+    fn weekday() {
+        let solution = Weekday::solve_once(test_date()).expect("did not find solution");
+        assert_solution(solution, 'A'..='J')
+    }
+
+    #[test]
+    fn weekday_board() {
+        assert_eq!(!weekday_bitboard_from_date(ymd(2022, 1, 8)), BitBoard(0x8000008000000002)); // Sat
+        assert_eq!(!weekday_bitboard_from_date(ymd(2020, 1, 8)), BitBoard(0x8000008000000200)); // Wed
+    }
+
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,18 +1,19 @@
 #![allow(dead_code)]
 
-use crate::variants::{CreaMakerspace, DragonFjord, JarringWords, Tetromino, Variant};
-use chrono::NaiveDate;
+use crate::variants::{CreaMakerspace, DragonFjord, JarringWords, Tetromino, Variant, Weekday};
+use chrono::NaiveDateTime;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 /// Finds the first solution for a given variant, and returns an array of piece bitmaps
-pub fn solve_once(month: u32, day: u32, variant: u32) -> Result<Box<[u64]>, String> {
-    let date = NaiveDate::from_ymd_opt(2020, month, day).unwrap();
+pub fn solve_once(epoch_ms: i64, variant: u32) -> Result<Box<[u64]>, String> {
+    let date = NaiveDateTime::from_timestamp_millis(epoch_ms).unwrap().date();
     let solution = match variant {
         0 => DragonFjord::solve_once(date),
         1 => JarringWords::solve_once(date),
         2 => CreaMakerspace::solve_once(date),
         3 => Tetromino::solve_once(date),
+        4 => Weekday::solve_once(date),
         _ => unimplemented!("Unsupported variant"),
     };
 
@@ -24,8 +25,8 @@ pub fn solve_once(month: u32, day: u32, variant: u32) -> Result<Box<[u64]>, Stri
             .collect::<Vec<u64>>()
             .into_boxed_slice()),
         None => Err(format!(
-            "No solution for variant {} on {}-{}",
-            variant, month, day
+            "No solution for variant {} on {}",
+            variant, date
         )),
     }
 }


### PR DESCRIPTION
This implements the puzzle described in https://github.com/keiichiw/a-puzzle-a-day-solver/issues/3

Performance isn't ideal: Where the other variants can be fully solved for a given date in 100-500ms, this variant requires 30s - 3m. I suspect that's the result of the extra pieces and extra valid squares for placement. It's still reasonably quick finding a single solution, but the web UI still feels a bit laggy, especially on specific dates (e.g. Jan 8, 2023). And the UI currently has no busy indicator, nor does it try to cache or preemptively find solutions - so it leaves much to be desired.