### PR TITLE
Use 32-bit BitPiece

### DIFF
--- a/src/bitpiece.rs
+++ b/src/bitpiece.rs
@@ -3,27 +3,41 @@ use std::fmt;
 use crate::bitboard::BitBoard;
 
 /// Each piece fits on 4x4 bit board.
+///
+/// We represent it with a u32 that represents half of a `BitBoard(u64)`
+/// Using a bitmaps 8 wide by 4 tall allows using basic shift operations
+/// to apply piece masks directly onto a `BitBoard`.
+/// The 4 left columns of bits are unused and should always be `0`
+///
+/// Example "bold plus" piece:
+///
+/// ```ignore
+/// 0 0 0 0 0 1 1 0
+/// 0 0 0 0 1 1 1 1
+/// 0 0 0 0 1 1 1 1
+/// 0 0 0 0 0 1 1 0
+/// ```
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub struct BitPiece(pub u16);
+pub struct BitPiece(pub u32);
 
 impl fmt::Debug for BitPiece {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "BitPiece(0x{:04x})", self.0)
+        write!(f, "BitPiece(0x{:08x})", self.0)
     }
 }
 
 impl BitPiece {
-    pub const fn new(b: u16) -> BitPiece {
+    pub const fn new(b: u32) -> BitPiece {
         BitPiece(b)
     }
 
     /// Assumes shape is aligned to LSB
     pub const fn width(&self) -> usize {
-        if self.0 & 0xEEEE == 0 {
+        if self.0 & 0xFEFEFEFE == 0 {
             1
-        } else if self.0 & 0xCCCC == 0 {
+        } else if self.0 & 0xFCFCFCFC == 0 {
             2
-        } else if self.0 & 0x8888 == 0 {
+        } else if self.0 & 0xF8F8F8F8 == 0 {
             3
         } else {
             4
@@ -32,11 +46,11 @@ impl BitPiece {
 
     /// Assumes shapes is aligned to LSB
     pub const fn height(&self) -> usize {
-        if self.0 & 0xFFF0 == 0 {
+        if self.0 & 0xFFFFFFF0 == 0 {
             1
-        } else if self.0 & 0xFF00 == 0 {
+        } else if self.0 & 0xFFFFF0F0 == 0 {
             2
-        } else if self.0 & 0xF000 == 0 {
+        } else if self.0 & 0xFFF0F0F0 == 0 {
             3
         } else {
             4
@@ -44,6 +58,8 @@ impl BitPiece {
     }
 
     /// Horizontal flip
+    ///
+    /// Remains in the half
     ///
     /// x' = 3 - x
     /// y' = y
@@ -54,8 +70,8 @@ impl BitPiece {
         while i < 4 {
             j = 0;
             while j < 4 {
-                if self.0 & (1 << (i * 4 + j)) != 0 {
-                    bp.0 |= 1 << (i * 4 + 3 - j)
+                if self.0 & (1 << (i * 8 + j)) != 0 {
+                    bp.0 |= 1 << (i * 8 + 3 - j)
                 }
                 j += 1;
             }
@@ -74,8 +90,8 @@ impl BitPiece {
         while i < 4 {
             j = 0;
             while j < 4 {
-                if self.0 & (1 << (4 * i + j)) != 0 {
-                    bp.0 |= 1 << (4 * j + 3 - i)
+                if self.0 & (1 << (8 * i + j)) != 0 {
+                    bp.0 |= 1 << (8 * j + 3 - i)
                 }
                 j += 1;
             }
@@ -87,47 +103,42 @@ impl BitPiece {
     /// Aligns the shape to the LSB (effectively moving it to the bottom-right of the bitmap)
     ///
     /// ```ignore
-    /// 1 1 1 0
-    /// 1 1 0 0
-    /// 0 0 0 0
-    /// 0 0 0 0
+    /// 0 0 0 0 1 1 1 0
+    /// 0 0 0 0 1 1 0 0
+    /// 0 0 0 0 0 0 0 0
+    /// 0 0 0 0 0 0 0 0
     /// ```
     ///
     /// becomes:
     ///
     /// ```ignore
-    /// 0 0 0 0
-    /// 0 0 0 0
-    /// 0 1 1 1
-    /// 0 1 1 0
+    /// 0 0 0 0 0 0 0 0
+    /// 0 0 0 0 0 0 0 0
+    /// 0 0 0 0 0 1 1 1
+    /// 0 0 0 0 0 1 1 0
     /// ```
     const fn align(&self) -> BitPiece {
         let mut bp = BitPiece(self.0);
-        if bp.0 & 0x7777 == 0 {
+        if bp.0 & 0x07070707 == 0 {
             bp.0 >>= 3;
-        } else if bp.0 & 0x3333 == 0 {
+        } else if bp.0 & 0x03030303 == 0 {
             bp.0 >>= 2;
-        } else if bp.0 & 0x1111 == 0 {
+        } else if bp.0 & 0x01010101 == 0 {
             bp.0 >>= 1;
         }
-        if bp.0 & 0x0FFF == 0 {
-            bp.0 >>= 12;
-        } else if bp.0 & 0x00FF == 0 {
+        if bp.0 & 0x000F0F0F == 0 {
+            bp.0 >>= 24;
+        } else if bp.0 & 0x00000F0F == 0 {
+            bp.0 >>= 16;
+        } else if bp.0 & 0x0000000F == 0 {
             bp.0 >>= 8;
-        } else if bp.0 & 0x000F == 0 {
-            bp.0 >>= 4;
         }
         bp
     }
 
     #[inline]
     pub fn to_bitboard(self, x: usize, y: usize) -> BitBoard {
-        let val = self.0 as u64;
-        let mut bb = val & 0xF;
-        bb |= (val & 0xF0) << 4;
-        bb |= (val & 0xF00) << 8;
-        bb |= (val & 0xF000) << 12;
-        BitBoard::new(bb << (y * 8 + x))
+        BitBoard::new((self.0 as u64) << (y * 8 + x))
     }
 }
 
@@ -137,42 +148,42 @@ mod tests {
 
     #[test]
     fn piece_align() {
-        assert_eq!(BitPiece(0x13), BitPiece(0x13).align());
-        assert_eq!(BitPiece(0x23), BitPiece(0x23 << 2).align());
-        assert_eq!(BitPiece(0x37), BitPiece(0x37 << 8).align());
-        assert_eq!(BitPiece(0x33), BitPiece(0x33 << 10).align());
-        assert_eq!(BitPiece(0x0F88), BitPiece(0xF880).align());
+        assert_eq!(BitPiece(0x103), BitPiece(0x103).align());
+        assert_eq!(BitPiece(0x203), BitPiece(0x203 << 2).align());
+        assert_eq!(BitPiece(0x307), BitPiece(0x307 << 8).align());
+        assert_eq!(BitPiece(0x303), BitPiece(0x303 << 10).align());
+        assert_eq!(BitPiece(0xF0808), BitPiece(0xF080800).align());
     }
 
     #[test]
     fn piece_rotate() {
-        let piece = BitPiece(0x31);
-        assert_eq!(BitPiece(0x13), piece.rotate());
-        assert_eq!(BitPiece(0x23), piece.rotate().rotate());
-        assert_eq!(BitPiece(0x32), piece.rotate().rotate().rotate());
-        assert_eq!(BitPiece(0x31), piece.rotate().rotate().rotate().rotate());
+        let piece = BitPiece(0x301);
+        assert_eq!(BitPiece(0x103), piece.rotate());
+        assert_eq!(BitPiece(0x203), piece.rotate().rotate());
+        assert_eq!(BitPiece(0x302), piece.rotate().rotate().rotate());
+        assert_eq!(BitPiece(0x301), piece.rotate().rotate().rotate().rotate());
     }
 
     #[test]
     fn piece_flip() {
-        assert_eq!(BitPiece(0x23), BitPiece(0x13).flip());
-        assert_eq!(BitPiece(0x137F), BitPiece(0x8CEF).flip());
-        assert_eq!(BitPiece(0x1248), BitPiece(0x8421).flip());
-        assert_eq!(BitPiece(0x1111), BitPiece(0x1111).flip());
+        assert_eq!(BitPiece(0x203), BitPiece(0x103).flip());
+        assert_eq!(BitPiece(0x103070F), BitPiece(0x80C0E0F).flip());
+        assert_eq!(BitPiece(0x1020408), BitPiece(0x8040201).flip());
+        assert_eq!(BitPiece(0x1010101), BitPiece(0x1010101).flip());
     }
 
     #[test]
     fn piece_to_bitboard() {
-        assert_eq!(BitPiece(0x23).to_bitboard(0, 0), BitBoard::new(0x0203));
-        assert_eq!(BitPiece(0x23).to_bitboard(1, 0), BitBoard::new(0x406));
-        assert_eq!(BitPiece(0x23).to_bitboard(0, 1), BitBoard::new(0x020300));
-        assert_eq!(BitPiece(0x23).to_bitboard(1, 1), BitBoard::new(0x040600));
+        assert_eq!(BitPiece(0x203).to_bitboard(0, 0), BitBoard::new(0x0203));
+        assert_eq!(BitPiece(0x203).to_bitboard(1, 0), BitBoard::new(0x406));
+        assert_eq!(BitPiece(0x203).to_bitboard(0, 1), BitBoard::new(0x020300));
+        assert_eq!(BitPiece(0x203).to_bitboard(1, 1), BitBoard::new(0x040600));
         assert_eq!(
-            BitPiece(0xFFFF).to_bitboard(0, 0),
+            BitPiece(0x0F0F0F0F).to_bitboard(0, 0),
             BitBoard::new(0x0F0F0F0F)
         );
         assert_eq!(
-            BitPiece(0xAAAA).to_bitboard(4, 4),
+            BitPiece(0x0A0A0A0A).to_bitboard(4, 4),
             BitBoard::new(0xA0A0A0A000000000)
         );
     }

--- a/src/piece.rs
+++ b/src/piece.rs
@@ -1,23 +1,23 @@
 use crate::bitpiece::BitPiece;
 
 // Unique variations of a given piece - rotations and reflections calculated at compile time
-pub const PIECE_RECT: Variations<2> = Variations::<2>::rotations(0x0077); // 6 squares
-pub const PIECE_U: Variations<4> = Variations::<4>::rotations(0x0313); // 5 squares
-pub const PIECE_CORNER: Variations<4> = Variations::<4>::rotations(0x0117); // 5 squares
-pub const PIECE_TALL_S: Variations<4> = Variations::<4>::rotations_and_reflections(0x0326); // 5 squares
-pub const PIECE_TALL_L: Variations<8> = Variations::<8>::rotations_and_reflections(0x001F); // 5 squares
-pub const PIECE_LONG_Z: Variations<8> = Variations::<8>::rotations_and_reflections(0x003E); // 5 squares
-pub const PIECE_UNEVEN_T: Variations<8> = Variations::<8>::rotations_and_reflections(0x002F); // 5 squares
-pub const PIECE_SIX: Variations<8> = Variations::<8>::rotations_and_reflections(0x0331); // 5 squares
+pub const PIECE_RECT: Variations<2> = Variations::<2>::rotations(0x707); // 6 squares
+pub const PIECE_U: Variations<4> = Variations::<4>::rotations(0x30103); // 5 squares
+pub const PIECE_CORNER: Variations<4> = Variations::<4>::rotations(0x10107); // 5 squares
+pub const PIECE_TALL_S: Variations<4> = Variations::<4>::rotations_and_reflections(0x30206); // 5 squares
+pub const PIECE_TALL_L: Variations<8> = Variations::<8>::rotations_and_reflections(0x10F); // 5 squares
+pub const PIECE_LONG_Z: Variations<8> = Variations::<8>::rotations_and_reflections(0x30E); // 5 squares
+pub const PIECE_UNEVEN_T: Variations<8> = Variations::<8>::rotations_and_reflections(0x20F); // 5 squares
+pub const PIECE_SIX: Variations<8> = Variations::<8>::rotations_and_reflections(0x30301); // 5 squares
 
-pub const PIECE_W: Variations<4> = Variations::<4>::rotations(0x0631); // 5 squares
-pub const PIECE_H: Variations<8> = Variations::<8>::rotations_and_reflections(0x0175); // 6 squares
-pub const PIECE_TALL_T: Variations<4> = Variations::<4>::rotations(0x0227); // 5 squares
-pub const PIECE_SQUARE: Variations<1> = Variations::<1>::new(0x0033); // 4 squares
-pub const PIECE_L: Variations<8> = Variations::<8>::rotations_and_reflections(0x0017); // 4 squares
-pub const PIECE_T: Variations<4> = Variations::<4>::rotations(0x0027); // 4 squares
-pub const PIECE_LINE: Variations<2> = Variations::<2>::rotations(0x000F); // 4 squares
-pub const PIECE_Z: Variations<4> = Variations::<4>::rotations_and_reflections(0x0036); // 4 squares
+pub const PIECE_W: Variations<4> = Variations::<4>::rotations(0x60301); // 5 squares
+pub const PIECE_H: Variations<8> = Variations::<8>::rotations_and_reflections(0x10705); // 6 squares
+pub const PIECE_TALL_T: Variations<4> = Variations::<4>::rotations(0x20207); // 5 squares
+pub const PIECE_SQUARE: Variations<1> = Variations::<1>::new(0x303); // 4 squares
+pub const PIECE_L: Variations<8> = Variations::<8>::rotations_and_reflections(0x107); // 4 squares
+pub const PIECE_T: Variations<4> = Variations::<4>::rotations(0x207); // 4 squares
+pub const PIECE_LINE: Variations<2> = Variations::<2>::rotations(0x0F); // 4 squares
+pub const PIECE_Z: Variations<4> = Variations::<4>::rotations_and_reflections(0x306); // 4 squares
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Variations<const N: usize>(pub [BitPiece; N]);
@@ -38,21 +38,21 @@ impl<const N: usize> Variations<N> {
 impl Variations<1> {
     #[allow(unused)]
     /// Instantiate a piece that has no unique rotations or reflections (fully symmetrical)
-    const fn new(shape: u16) -> Variations<1> {
+    const fn new(shape: u32) -> Variations<1> {
         Variations([BitPiece::new(shape)])
     }
 }
 
 impl Variations<2> {
     /// Generate variations for a piece that only has 1 extra unique rotation
-    const fn rotations(shape: u16) -> Variations<2> {
+    const fn rotations(shape: u32) -> Variations<2> {
         Variations([BitPiece::new(shape), BitPiece::new(shape).rotate()])
     }
 }
 
 impl Variations<4> {
     /// Generate variations for pieces that have 4 unique orientations (reflections are not unique)
-    const fn rotations(shape: u16) -> Variations<4> {
+    const fn rotations(shape: u32) -> Variations<4> {
         let mut variations = [BitPiece::new(shape); 4];
         variations[1] = variations[0].rotate();
         variations[2] = variations[1].rotate();
@@ -61,7 +61,7 @@ impl Variations<4> {
     }
 
     /// Generate variations for pieces that have 4 unique orientations (2 rotations and their reflections)
-    const fn rotations_and_reflections(shape: u16) -> Variations<4> {
+    const fn rotations_and_reflections(shape: u32) -> Variations<4> {
         let mut variations = [BitPiece::new(shape); 4];
         variations[1] = variations[0].rotate();
         variations[2] = variations[1].flip();
@@ -72,7 +72,7 @@ impl Variations<4> {
 
 impl Variations<8> {
     /// Generate variations for pieces that have 8 unique orientations
-    const fn rotations_and_reflections(shape: u16) -> Variations<8> {
+    const fn rotations_and_reflections(shape: u32) -> Variations<8> {
         let mut variations = [BitPiece::new(shape); 8];
         variations[1] = variations[0].rotate();
         variations[2] = variations[1].rotate();


### PR DESCRIPTION
This allows `BitPiece::to_bitboard` (the original hotloop)
  to be reduced to just a multiple, add, and shift operation
Experimentally, this seems to be about a 15-30% performance increase.